### PR TITLE
chore: upgrade vite to v6.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "sass": "^1.85.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.42.0",
-    "vite": "^6.3.5",
+    "vite": "^6.3.6",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.5.2(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))
+        version: 4.5.2(vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))
       '@vitest/coverage-v8':
         specifier: ^3.1.3
         version: 3.2.3(vitest@3.2.3)
@@ -85,11 +85,11 @@ importers:
         specifier: ^8.42.0
         version: 8.42.0(eslint@9.34.0(jiti@2.4.2))(typescript@5.7.3)
       vite:
-        specifier: ^6.3.5
-        version: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
+        specifier: ^6.3.6
+        version: 6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.3)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.7.3)(vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))
       vitest:
         specifier: ^3.1.3
         version: 3.2.3(@types/node@24.0.1)(@vitest/ui@3.2.3)(jiti@2.4.2)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
@@ -2561,8 +2561,8 @@ packages:
       vite:
         optional: true
 
-  vite@6.3.5:
-    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+  vite@6.3.6:
+    resolution: {integrity: sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -3486,7 +3486,7 @@ snapshots:
       '@typescript-eslint/types': 8.42.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.5.2(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))':
+  '@vitejs/plugin-react@4.5.2(vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.4)
@@ -3494,7 +3494,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.11
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3525,13 +3525,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.3(vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.3':
     dependencies:
@@ -5391,7 +5391,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5406,18 +5406,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.7.3)
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0):
+  vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -5436,7 +5436,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.3(vite@6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
@@ -5454,7 +5454,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.3.6(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
       vite-node: 3.2.3(@types/node@24.0.1)(jiti@2.4.2)(sass@1.89.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
Closes:
- https://github.com/tyalau/react-ts-boilerplate/security/dependabot/12
- https://github.com/tyalau/react-ts-boilerplate/security/dependabot/13